### PR TITLE
增加显示表格单元格边框线属性bordered及bug修复

### DIFF
--- a/components/table/base/styles.ts
+++ b/components/table/base/styles.ts
@@ -228,30 +228,18 @@ export const defaultCSSVariables = {
   '--cell-border-horizontal': '1px solid #dfe3e8',
   '---cell-border-vertical': '1px solid #dfe3e8',
   '--header-cell-border': '1px solid #dfe3e8',
+  '--cell-border-vertical': '1px solid #dfe3e8',
   '--header-cell-border-horizontal': '1px solid #dfe3e8',
-}
-
-export const defaultConditionCSSVariables = {
-  '--header-cell-border-vertical': '1px solid #dfe3e8',
-  '--cell-border-vertical': '1px solid #dfe3e8'
+  '--header-cell-border-vertical': '1px solid #dfe3e8'
 }
 
 export const variableConst = getCssVariableText(defaultCSSVariables)
 
+const notBorderedStyleMixin = css`
+  --cell-border-vertical: none;
+  --header-cell-border-vertical: none;
+`
 const borderedStyleMixin = css`
-  //添加竖直边框线var变量
-  --cell-border-vertical: ${defaultConditionCSSVariables['--cell-border-vertical']};
-  --header-cell-border-vertical: ${defaultConditionCSSVariables['--header-cell-border-vertical']};
-
-  //兼容拖拽列宽、分组列下隐藏th的border-right: none情况
-  //todo: 应去掉以上强制隐藏右边框的代码！，默认就使用--header-cell-border-vertical的颜色
-  th.resizeable{
-    border-right: var(--header-cell-border-vertical)
-  }
-  th.${Classes.leaf} {
-    border-right: var(--header-cell-border-vertical);
-  }
-
   //th隐藏列宽拖拽的背景色，使用th的右边框代替
   .${Classes.tableHeaderCellResize}::after{
     background-color: inherit;
@@ -279,8 +267,11 @@ export const StyledArtTableWrapper = styled.div`
     ${outerBorderStyleMixin};
   }
 
-  // 表格开启边框线，处理th、td的单元格左右边框线（默认无该边框线）
-  &.${Classes.artTableBordered} {
+  // 表格不启用边框线，隐藏th、td的单元格左右边框线
+  &:not(.${Classes.artTableBordered}) {
+    ${notBorderedStyleMixin}
+  }
+  &.${Classes.artTableBordered}{
     ${borderedStyleMixin}
   }
 
@@ -419,11 +410,11 @@ export const StyledArtTableWrapper = styled.div`
   }
 
   th.resizeable{
-    border-right:none
+    border-right: var(--header-cell-border-vertical)
   }
 
   th.${Classes.leaf} {
-    border-right: none;
+    border-right: var(--header-cell-border-vertical);
     border-bottom: none;
   }
 
@@ -654,6 +645,13 @@ export const StyledArtTableWrapper = styled.div`
     border-top: var(--cell-border-horizontal);
   }
   //#endregion
+  
+  //#region 拖拽列宽大小
+  .${Classes.tableHeaderCellResize}::after{
+    background-color: var(--border-color);
+  }
+  //#endregion
+
   `
 export const ButtonCSS = css`
   ${variableConst}

--- a/components/table/base/styles.ts
+++ b/components/table/base/styles.ts
@@ -7,6 +7,7 @@ const prefix = 'kd-'
 export const Classes = {
   /** BaseTable 表格组件的外层包裹 div */
   artTableWrapper: `${prefix}table-wrapper`,
+  artTableBordered: `${prefix}table-bordered`,
 
   artTable: `${prefix}table`,
   tableHeaderMain: `${prefix}table-header-main`,
@@ -153,13 +154,13 @@ export type BaseTableCSSVariables = Partial<{
   '--border-color': string
   /** 单元格边框，默认为 1px solid #dfe3e8 */
   '--cell-border': string
-  /** 单元格上下边框，默认为 #dfe3e8 */
+  /** 单元格上下边框，默认为 none ，默认值为 1px solid #dfe3e8 */
   '--cell-border-horizontal': string
   /** 单元格左右边框，默认为 #dfe3e8 */
   '--cell-border-vertical': string
   /** 表头单元格边框，默认为 1px solid #dfe3e8 */
   '--header-cell-border': string
-  /** 表头单元格上下边框，默认为 1px solid #dfe3e8 */
+  /** 表头单元格上下边框，默认为 none ，默认值为 1px solid #dfe3e8 */
   '--header-cell-border-horizontal': string
   /** 表头单元格左右边框，默认为 1px solid #dfe3e8 */
   '--header-cell-border-vertical': string
@@ -177,7 +178,7 @@ const outerBorderStyleMixin = css`
   }
   td.${Classes.last},
   th.${Classes.last} {
-    --border-right: none;
+    border-right: none;
   }
 
   thead tr.${Classes.first} th,
@@ -230,7 +231,32 @@ export const defaultCSSVariables = {
   '--header-cell-border-horizontal': '1px solid #dfe3e8',
 }
 
+export const defaultConditionCSSVariables = {
+  '--header-cell-border-vertical': '1px solid #dfe3e8',
+  '--cell-border-vertical': '1px solid #dfe3e8'
+}
+
 export const variableConst = getCssVariableText(defaultCSSVariables)
+
+const borderedStyleMixin = css`
+  //添加竖直边框线var变量
+  --cell-border-vertical: ${defaultConditionCSSVariables['--cell-border-vertical']};
+  --header-cell-border-vertical: ${defaultConditionCSSVariables['--header-cell-border-vertical']};
+
+  //兼容拖拽列宽、分组列下隐藏th的border-right: none情况
+  //todo: 应去掉以上强制隐藏右边框的代码！，默认就使用--header-cell-border-vertical的颜色
+  th.resizeable{
+    border-right: var(--header-cell-border-vertical)
+  }
+  th.${Classes.leaf} {
+    border-right: var(--header-cell-border-vertical);
+  }
+
+  //th隐藏列宽拖拽的背景色，使用th的右边框代替
+  .${Classes.tableHeaderCellResize}::after{
+    background-color: inherit;
+  }
+`
 
 export const StyledArtTableWrapper = styled.div`
   :root {
@@ -251,6 +277,11 @@ export const StyledArtTableWrapper = styled.div`
   // 表格外边框由 art-table-wrapper 提供，而不是由单元格提供
   &.use-outer-border {
     ${outerBorderStyleMixin};
+  }
+
+  // 表格开启边框线，处理th、td的单元格左右边框线（默认无该边框线）
+  &.${Classes.artTableBordered} {
+    ${borderedStyleMixin}
   }
 
   .no-scrollbar {

--- a/components/table/base/table.tsx
+++ b/components/table/base/table.tsx
@@ -18,7 +18,6 @@ import {
   Classes,
   LOCK_SHADOW_PADDING,
   StyledArtTableWrapper,
-  defaultCSSVariables
 } from './styles'
 import {
   addResizeObserver,
@@ -29,36 +28,13 @@ import {
   sum,
   syncScrollLeft,
   throttledWindowResize$,
-  composeRowPropsGetter,
   getTableScrollFooterDOM,
-  getTableScrollHeaderDOM
+  getTableScrollHeaderDOM,
+  cssPolifill
 } from './utils'
-import cssVars from 'css-vars-ponyfill'
+
 import { console, browserType } from '../utils'
 import getTableRenderTemplate from './renderTemplates'
-
-const cssPolifill = ({ variables, enableCSSVariables }) => {
-  // const style = document.createElement('style')
-  // style.type = 'text/css'
-  // style.innerHTML = '.aaa{ --color: red; }'
-  // document.getElementsByTagName('head').item(0).appendChild(style)
-
-  // const variableNames = variableConst.match(/--.*?(?=:)/g)
-  // variables = variableNames.map((name) => rootElement.style[name])
-  if (enableCSSVariables === false) {
-    return
-  }
-
-  cssVars({
-    // exclude: 'link[href*="semantic-ui"]',
-    // onlyLegacy: false,
-    // rootElement: rootElement,
-    include: 'style[data-styled]',
-    variables: Object.assign({}, defaultCSSVariables, variables),
-    watch: true,
-    silent: true
-  })
-}
 
 let propsDotEmptyContentDeprecatedWarned = false
 function warnPropsDotEmptyContentIsDeprecated () {
@@ -110,6 +86,8 @@ export interface BaseTableProps {
   scrollbarWidth?: number
   /** 使用来自外层 div 的边框代替单元格的外边框 */
   useOuterBorder?: boolean
+  /** 显示表格单元格边框线 */
+  bordered?: boolean
 
   /** 表格是否在加载中 */
   isLoading?: boolean
@@ -544,7 +522,8 @@ export class BaseTable extends React.Component<BaseTableProps, BaseTableState> {
       isLoading,
       getTableProps,
       footerDataSource,
-      components
+      components,
+      bordered
     } = this.props
 
     const artTableWrapperClassName = cx(
@@ -557,6 +536,7 @@ export class BaseTable extends React.Component<BaseTableProps, BaseTableState> {
         'sticky-header': isStickyHeader ?? isStickyHead,
         'has-footer': footerDataSource.length > 0,
         'sticky-footer': isStickyFooter,
+        [Classes.artTableBordered]: bordered,
         'ie-polyfill-wrapper': browserType.isIE
       },
       className
@@ -597,8 +577,8 @@ export class BaseTable extends React.Component<BaseTableProps, BaseTableState> {
     this.initSubscriptions()
     this.didMountOrUpdate()
     // console.log('did mount end')
-    const { cssVariables, enableCSSVariables } = this.props
-    cssPolifill({ variables: cssVariables || {}, enableCSSVariables })
+    const { cssVariables, enableCSSVariables, bordered } = this.props
+    cssPolifill({ variables: cssVariables || {}, enableCSSVariables, bordered })
     this.props.setTableWidth?.(this.domHelper.tableBody.clientWidth)
     this.props.setTableDomHelper?.(this.domHelper)
   }

--- a/components/table/base/utils.tsx
+++ b/components/table/base/utils.tsx
@@ -3,9 +3,12 @@ import { asyncScheduler, BehaviorSubject, defer, fromEvent, Subscription } from 
 import { map, throttleTime } from 'rxjs/operators'
 import ResizeObserver from 'resize-observer-polyfill'
 import * as styledComponents from 'styled-components'
+import cssVars from 'css-vars-ponyfill'
+
 import mergeCellProps from '../utils/mergeCellProps'
 import { TableDOMHelper } from './helpers/TableDOMUtils'
 import { browserType } from '../utils'
+import { defaultCSSVariables, defaultConditionCSSVariables } from './styles'
 
 /** styled-components 类库的版本，ali-react-table 同时支持 v3 和 v5 */
 export const STYLED_VERSION = (styledComponents as any).createGlobalStyle != null ? 'v5' : 'v3'
@@ -171,4 +174,38 @@ export function getTableScrollHeaderDOM (domHelper: TableDOMHelper) : HTMLDivEle
 
 export function getTableScrollFooterDOM (domHelper: TableDOMHelper) : HTMLDivElement {
   return browserType.isIE ? domHelper.tableFooterMain : domHelper.tableFooter
+}
+
+export const cssPolifill = (
+  {
+    variables,
+    enableCSSVariables,
+    bordered
+  } : {
+    variables: {[key: string]: any}
+    enableCSSVariables?: boolean
+    bordered?: boolean
+  }
+) => {
+  if (enableCSSVariables === false) {
+    return
+  }
+
+  const conditionVariables = {}
+
+  // 默认情况下td、th无左右边框，开启`bordered`属性后才开启
+  if (bordered) {
+    conditionVariables['--cell-border-vertical'] = defaultConditionCSSVariables['--cell-border-vertical']
+    conditionVariables['--header-cell-border-vertical'] = defaultConditionCSSVariables['--header-cell-border-vertical']
+  }
+
+  cssVars({
+    // exclude: 'link[href*="semantic-ui"]',
+    // onlyLegacy: false,
+    // rootElement: rootElement,
+    include: 'style[data-styled]',
+    variables: Object.assign(conditionVariables, defaultCSSVariables, variables),
+    watch: true,
+    silent: true
+  })
 }

--- a/components/table/base/utils.tsx
+++ b/components/table/base/utils.tsx
@@ -8,7 +8,7 @@ import cssVars from 'css-vars-ponyfill'
 import mergeCellProps from '../utils/mergeCellProps'
 import { TableDOMHelper } from './helpers/TableDOMUtils'
 import { browserType } from '../utils'
-import { defaultCSSVariables, defaultConditionCSSVariables } from './styles'
+import { defaultCSSVariables } from './styles'
 
 /** styled-components 类库的版本，ali-react-table 同时支持 v3 和 v5 */
 export const STYLED_VERSION = (styledComponents as any).createGlobalStyle != null ? 'v5' : 'v3'
@@ -191,12 +191,12 @@ export const cssPolifill = (
     return
   }
 
-  const conditionVariables = {}
+  const conditionCSSVariables = {}
 
-  // 默认情况下td、th无左右边框，开启`bordered`属性后才开启
-  if (bordered) {
-    conditionVariables['--cell-border-vertical'] = defaultConditionCSSVariables['--cell-border-vertical']
-    conditionVariables['--header-cell-border-vertical'] = defaultConditionCSSVariables['--header-cell-border-vertical']
+  // 默认情况下存在td、th无左右边框，开启`bordered`属性后才开启，否则隐藏这两种属性
+  if (!bordered) {
+    conditionCSSVariables['--cell-border-vertical'] = 'none'
+    conditionCSSVariables['--header-cell-border-vertical'] = 'none'
   }
 
   cssVars({
@@ -204,7 +204,7 @@ export const cssPolifill = (
     // onlyLegacy: false,
     // rootElement: rootElement,
     include: 'style[data-styled]',
-    variables: Object.assign(conditionVariables, defaultCSSVariables, variables),
+    variables: Object.assign({}, defaultCSSVariables, variables, conditionCSSVariables),
     watch: true,
     silent: true
   })

--- a/components/table/pipeline/features/columnDrag.tsx
+++ b/components/table/pipeline/features/columnDrag.tsx
@@ -206,13 +206,12 @@ export function columnDrag (opts: ColumnDragOptions = {}) {
                 })
               }
               function handleMouseUp (e) {
-                e.stopPropagation()
                 document.body.removeEventListener('mousemove', handleMouseMove)
                 document.body.removeEventListener('mouseup', handleMouseUp)
                 window.removeEventListener('selectstart', disableSelect)
-                // 阻止列头点击事件，防止拖动后触发列头过滤事件
                 if (_isMoveWhenClicking(mouseDownClientX, mouseDownClientY, e.clientX, e.clientY)) {
-                  currentTarget.addEventListener('click', stopClickPropagation)
+                  e.stopPropagation() // 存在移动就阻止冒泡
+                  currentTarget.addEventListener('click', stopClickPropagation) // 阻止列头点击事件，防止拖动后触发列头过滤事件
                 }
                 window.requestAnimationFrame(() => {
                   // 取消阻止列头点击事件

--- a/components/table/pipeline/features/columnResizeWidth.tsx
+++ b/components/table/pipeline/features/columnResizeWidth.tsx
@@ -28,7 +28,6 @@ const TableHeaderCellResize = styled.div`
     width: 1px;
     height: calc(100% - 14px);
     top: 7px;
-    background-color: var(--border-color);
   }
 `
 

--- a/components/table/pipeline/features/filter/DefaultFilterContent.tsx
+++ b/components/table/pipeline/features/filter/DefaultFilterContent.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import cx from 'classnames'
 
 import { DefaultFilterPanelProps } from '../../../interfaces'
 import { DEFAULT_FILTER_OPTIONS } from './util'
 import { Classes, ButtonCSS } from '../../../base/styles'
+import KeyCode from '../../../utils/keyCode'
 
 const DefaultFilterContentStyle = styled.div`
   display: flex;
@@ -87,6 +88,7 @@ const DefaultFilterContentStyle = styled.div`
 function DefaultFilterContent ({ setFilterModel, filterModel, hidePanel }: DefaultFilterPanelProps) {
   const [selectedValue, setSelectedValue] = React.useState(filterModel?.filterCondition || 'contain')
   const [innerValue, setInnerValue] = React.useState(filterModel?.filter || '')
+  const inputRef = useRef<HTMLInputElement>()
   const handleClick = React.useCallback((option) => {
     setSelectedValue(option.key)
   }, [])
@@ -102,10 +104,23 @@ function DefaultFilterContent ({ setFilterModel, filterModel, hidePanel }: Defau
     })
   }
 
+  const handleKeyDown = (e) => {
+    if (e.keyCode === KeyCode.ENTER) {
+      confirm()
+    }
+  }
+
   useEffect(() => {
     setSelectedValue(filterModel?.filterCondition || 'contain')
     setInnerValue(filterModel?.filter || '')
   }, [filterModel])
+
+  useEffect(() => {
+    // 兼容设置焦点后发生滚动
+    setTimeout(() => {
+      inputRef.current?.focus({ preventScroll: true })
+    })
+  }, [])
 
   return (
     <DefaultFilterContentStyle>
@@ -132,6 +147,8 @@ function DefaultFilterContent ({ setFilterModel, filterModel, hidePanel }: Defau
               className='filter-search-inner'
               value={innerValue}
               onChange={(e) => { setInnerValue(e.target.value) }}
+              onKeyDown={handleKeyDown}
+              ref={inputRef}
             />
           </div>
         )

--- a/components/table/pipeline/features/filter/FilterPanel.tsx
+++ b/components/table/pipeline/features/filter/FilterPanel.tsx
@@ -37,8 +37,8 @@ const FilterPanelStyle = styled.div`
 
 const useWindowEvents = (func, evens) => {
   React.useEffect(() => {
-    evens.forEach(event => window.addEventListener(event, func))
-    return () => evens.forEach(event => window.removeEventListener(event, func))
+    evens.forEach(event => window.addEventListener(event, func, true))
+    return () => evens.forEach(event => window.removeEventListener(event, func, true))
   }, [evens, func])
 }
 
@@ -66,22 +66,18 @@ function FilterPanel ({ style, children, position, filterIcon, onClose }) {
     setVisible(true)
   }, [position])
 
-  const hasPopupMouseDown = useRef(false)
-  const mouseDownTimeout = useRef<undefined|number>()
-  const handleMouseDown = (e) => {
-    // 当弹出的过滤面板内部发生鼠标按下事件时，标记当前事件，并在下个周期清除标记，用来确定鼠标按下发生在过滤面板内部
+  const hasPopupMouseEvent = useRef(false)
+  const handleMouseEvent = () => {
+    // 当弹出的过滤面板内部发生鼠标按下、抬起事件时，标记当前事件，并在click捕获期清除标记，用来确定鼠标按下、抬起发生在过滤面板内部
     // 利用了React.createPortal冒泡是根据React Tree的特性：
     // https://jwwnz.medium.com/react-portals-and-event-bubbling-8df3e35ca3f1
-    hasPopupMouseDown.current = true
-    clearTimeout(mouseDownTimeout.current)
-    mouseDownTimeout.current = window.setTimeout(() => {
-      hasPopupMouseDown.current = false
-    }, 0)
+    hasPopupMouseEvent.current = true
   }
 
   useWindowEvents((e) => {
-    !isContainPanel(e) && !hasPopupMouseDown.current && onClose()
-  }, ['mousedown'])
+    !isContainPanel(e) && !hasPopupMouseEvent.current && onClose()
+    hasPopupMouseEvent.current = false
+  }, ['click'])
 
   return (
     <FilterPanelStyle
@@ -91,7 +87,8 @@ function FilterPanel ({ style, children, position, filterIcon, onClose }) {
         top: visible ? perfectPosition.y : 0,
         opacity: visible ? 1 : 0
       }}
-      onMouseDown={handleMouseDown}
+      onMouseDown={handleMouseEvent}
+      onMouseUp={handleMouseEvent}
       ref={ref}
     >
       <div className={'popup-header'}>

--- a/components/table/utils/keyCode.ts
+++ b/components/table/utils/keyCode.ts
@@ -1,0 +1,6 @@
+
+const KeyCode = {
+  ENTER: 13
+}
+
+export default KeyCode


### PR DESCRIPTION
@xiaolinsq 

feat: [增加显示表格单元格边框线属性bordered](https://github.com/kdcloudone/table/commit/6935a816c7919a6b4906c7885b51281f0d3104fd)
fix：
- [开启列拖拽移动功能时点击列头总是阻止mouseup事件冒泡](https://github.com/kdcloudone/table/commit/03270450430e31f048747f780090d96e7d594254)
- [mousedown事件被阻止冒泡后导致过滤面板无法关闭](https://github.com/kdcloudone/table/commit/4a33a9c8b9fef77635e9926925e2346e33b77f49)