### PR TITLE
fix: 部分浏览器(chrome109)最后一个单元格的列宽拖拽区域绝对定位超出表格，导致表格竖分割线无法对齐

### DIFF
--- a/components/table/base/styles.ts
+++ b/components/table/base/styles.ts
@@ -661,6 +661,14 @@ export const StyledArtTableWrapper = styled.div`
   .${Classes.tableHeaderCellResize}::after{
     background-color: var(--border-color);
   }
+  //解决部分浏览器(chrome109)最后一个单元格的列宽拖拽区域绝对定位超出表格，导致表格竖分割线无法对齐
+  .${Classes.tableHeaderRow} th.${Classes.last} .${Classes.tableHeaderCellResize}{
+    right: 0;
+    width: 5px;
+    &::after{
+      left: 5px;
+    }
+  }
   //#endregion
 
   `

--- a/components/table/demo/editTable.md
+++ b/components/table/demo/editTable.md
@@ -29,8 +29,11 @@ const [activeCell, setActiveCell] = useState({ row: -1, col: -1 });
     return {
       style: {
       },
-      onClick(event) {
-        setActiveCell({ row: rowIndex, col });
+      onClick (event) {
+        const { row: preRow, col: preCol } = activeCell
+        if (preRow !== rowIndex || preCol !== col) {
+          setActiveCell({ row: rowIndex, col })
+        }
       }
     };
   };


### PR DESCRIPTION
fix: 部分浏览器(chrome109)最后一个单元格的列宽拖拽区域绝对定位超出表格，导致表格竖分割线无法对齐
docs: 修复可编辑表格样例鼠标点击不可切换光标