### PR TITLE
fix: 表头末尾标题拖拽列宽图标超出表格宽度，导致滚动内容时列头和表体无法对齐

### DIFF
--- a/components/table/base/styles.ts
+++ b/components/table/base/styles.ts
@@ -666,7 +666,7 @@ export const StyledArtTableWrapper = styled.div`
     right: 0;
     width: 5px;
     &::after{
-      left: 5px;
+      left: 4px;
     }
   }
   //#endregion


### PR DESCRIPTION
@xiaolinsq 