### PR TITLE
fix: 表格无页脚数据时，滚动条占位显示导致页脚高度为1px

### DIFF
--- a/components/table/base/table.tsx
+++ b/components/table/base/table.tsx
@@ -457,10 +457,14 @@ export class BaseTable extends React.Component<BaseTableProps, BaseTableState> {
             limit: Infinity
           }}
         />
-        <div
-          className={Classes.verticalScrollPlaceholder}
-          style={this.hasScrollY ? { width: this.getScrollBarWidth(), visibility: 'initial' } : undefined}>
-        </div>
+        {
+          footerDataSource.length > 0
+            ? <div
+              className={Classes.verticalScrollPlaceholder}
+              style={this.hasScrollY ? { width: this.getScrollBarWidth(), visibility: 'initial' } : undefined}>
+            </div>
+            : null
+        }
       </div>
     )
   }


### PR DESCRIPTION
@xiaolinsq 